### PR TITLE
Removed unnecessary `api/` + corrected README name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# cli.omg
+# cli.lol
 
 A command line interface to [omg.lol](https://omg.lol)'s API.

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,3 +1,0 @@
-module omg.lol/api
-
-go 1.20

--- a/go.work
+++ b/go.work
@@ -2,7 +2,6 @@ go 1.20
 
 use (
 	.
-	./api
 	./cmd
 	./internal/http
 	./lib/profile


### PR DESCRIPTION
Using [golang standards' project layout]
(https://github.com/golang-standards/project-layout)
as a reference,
`api/` is mainly used for api definitions.
Example types of files:

- OpenAPI/Swagger specs
- json scheme files
- protocol definition files
- etc

**Fixed name in `README.md`**
cli.omg -> cli.lol
